### PR TITLE
🐇

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -97,6 +97,9 @@ module.exports = {
         const destination = flags["dest"] || defaultDest;
         const baseurl = flags["baseurl"] || "";
         const port = this.checkPortNumber(flags["port"]) || defaultPort;
+        const split = flags["split"] || 1;
+        const partition = flags["partition"] || 1;
+
         let options = {
             cwd: process.cwd(),
 
@@ -111,8 +114,10 @@ module.exports = {
                 path: "/"
             } ,
             flags:{
-                overwrite: flags["overwrite"]
-            }           
+                overwrite: flags["overwrite"],
+                split,
+                partition
+            }
         };
 
         options.dist.fullPathToSource = path.resolve(options.cwd, options.dist.src);

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ Flags:
     -d | --dest     The destination folder to clone the files to. Defaults to dist/prod
     -b | --baseurl  The filename to prepend to the files in the source.
     -p | --port     The portnumber to serve the cloned site on.
+    --split         The number of partitions to divide files into
+    --partition     The partition number to process
 
 Commands:
     --Command--                                                     --Reqd flags--
@@ -50,6 +52,16 @@ const inputs = meow(
         overwrite: {
             type: 'boolean',
             alias: 'o'
+        },
+        split: {
+            type: 'number',
+            alias: null,
+            default: 1
+        },
+        parition: {
+            type: 'number',
+            alias: null,
+            default: 1
         }
     }
 });

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const inputs = meow(
             alias: null,
             default: 1
         },
-        parition: {
+        partition: {
             type: 'number',
             alias: null,
             default: 1

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,9 +64,9 @@ module.exports = {
      *          "assets":   returns all files that "css" and "html" does not return.
      * @return {object} The files grouped by `css`, `html`, and `other`.
      */
-    _fetchFiles: async function(dir, type = "any", parition){
+    _fetchFiles: async function(dir, type = "any", partition){
         try {
-            let { split: _split, partition: _partitionNumber } = { split: 1, partition: 1, ...parition }
+            let { split: _split, partition: _partitionNumber } = { split: 1, partition: 1, ...partition }
             let filesByType = {
                 css: [],
                 html: [],

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,5 +1,5 @@
 const fs = require("fs-extra");
-const path = require("path");
+const Path = require("path");
 const readlineSync = require("readline-sync");
 const util = require("util");
 const del = require("del");
@@ -22,6 +22,31 @@ const regex = {
     any: /(:?)/
 }
 
+const getFilesRecursive = async (path) => {
+    let stats = await stat(path);
+
+    if( stats.isSymbolicLink() ) {
+        return [];
+    }
+
+    if (stats && stats.isDirectory()){
+        // TODO: this could be done with `node-glob` and avoid the recursive call, and regex file checks.
+        let files = await readdir(path);
+        
+        let promises = files.map((file) => {
+            let fullpath = Path.resolve(path, file);
+            
+            return getFilesRecursive(fullpath);
+        });
+
+        let result = await Promise.all(promises);
+        
+        return result.flat();
+    }
+
+    return [path];
+}
+
 module.exports = {
 
     /**
@@ -37,62 +62,40 @@ module.exports = {
      *          "html":     returns only .html and .htm files.
      * 
      *          "assets":   returns all files that "css" and "html" does not return.
-     * @param {boolean} isRoot True if this method call is the root call in the recursive stack.
-     * @return {string[]} The list of files from dir.
+     * @return {object} The files grouped by `css`, `html`, and `other`.
      */
-    _fetchFiles: async function(dir, type = "any", isRoot = true){
-        
-        if (isRoot) log("fetching...")
-        let filesByType = {};
+    _fetchFiles: async function(dir, type = "any", parition){
+        try {
+            let { split: _split, partition: _partitionNumber } = { split: 1, partition: 1, ...parition }
+            let filesByType = {
+                css: [],
+                html: [],
+                other: []
+            };
 
-        let reg;
-        if (type === "css") reg = regex.css;
-        else if (type === "html") reg = regex.html;
-        else if (type === "assets") reg = null;
-        else reg = regex.any;
+            let files = await getFilesRecursive(dir);
+            
+            let split = Math.max(_split || 1, 1);
+            let partitionNumber = Math.min(split, Math.max(_partitionNumber || 1, 1));
+            let fileCount = files.length;
+            let partitionSize = fileCount / split;
+            let partitionStart = (partitionNumber - 1) * partitionSize;
+            let partitionEnd = partitionStart + partitionSize;
+            let filePartition = files.slice(partitionStart, partitionEnd);
 
-        try{
-            let files = await readdir(dir);
+            for (let file of filePartition){
+                let ext = Path.extname(file);
 
-            for (let file of files){
-                file = path.resolve(dir, file);
-                let stats = await stat(file);
-
-                if( stats.isSymbolicLink() ) {
-                    return undefined;
-                }
-                if (stats && stats.isDirectory()){
-                    const res = await this._fetchFiles(file, type, false);
-                    if (res.css){
-                        if (!filesByType.css) filesByType.css = [];
-                        filesByType.css = filesByType.css.concat(res.css);
-                    } 
-                    if (res.html) {
-                        if (!filesByType.html) filesByType.html = [];
-                        filesByType.html = filesByType.html.concat(res.html);
-                    }
-                    if (res.other) {
-                        if (!filesByType.other) filesByType.other = [];
-                        filesByType.other = filesByType.other.concat(res.other);
-                    } 
+                if(regex.css.test(ext)){
+                    filesByType.css.push(file);
+                } else if (regex.html.test(ext)) {
+                    filesByType.html.push(file);
                 } else {
-                    let ext = path.extname(file);
-
-                    if(regex.css.test(ext)){
-                        if (!filesByType.css) filesByType.css = [];
-                        filesByType.css.push(file);
-                    } else if (regex.html.test(ext)) {
-                        if (!filesByType.html) filesByType.html = [];
-                        filesByType.html.push(file);
-                    } else {
-                        if (!filesByType.other) filesByType.other = [];
-                        filesByType.other.push(file);
-                    }
-                    //fileArray.push(file);              
+                    filesByType.other.push(file);
                 }
             }
-            return filesByType;
 
+            return filesByType;
         } catch (err){
             return undefined;
         }
@@ -124,7 +127,7 @@ module.exports = {
                 if (!file) return undefined;
 
                 let stub = file.replace(source, ""); // the path of the file, relative to the source.
-                let newpath = path.join(destination, stub);
+                let newpath = Path.join(destination, stub);
 
                 await copy(file, newpath, { overwrite: true }); 
                     copiedFiles.push(newpath);             
@@ -165,11 +168,12 @@ module.exports = {
      * @param {Object} options The options object.
      */
     build: async function ( options ) {
-        
+        let { flags } = options;
+        let { split, partition } = flags;
         let del = await this.clean( options );
         if (typeof del === "number") return del; //errored in clean
      
-        let sourceFiles = await this._fetchFiles(options.dist.fullPathToSource);
+        let sourceFiles = await this._fetchFiles(options.dist.fullPathToSource, "any", { split, partition });
         if (!sourceFiles) return 1;
 
         let otherFiles = await this.clone_assets(options, sourceFiles.other);
@@ -215,7 +219,9 @@ module.exports = {
      */
     clone_assets: async function ( options, files = null ) {
         if(!files){
-            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "assets");
+            let { flags } = options;
+            let { split, partition } = flags;
+            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "assets", { split, partition });
             if (!fetchedFiles) return 1;
             files = fetchedFiles.other;
         }
@@ -255,9 +261,11 @@ module.exports = {
      * @returns {[String]} The copied files (TODO)
      */
     rewrite_css: async function( options, files = null ){
+        let { flags } = options;
+        let { split, partition } = flags;
 
         if (!files){
-            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "css");
+            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "css", { split, partition });
             if (!fetchedFiles) return 1;   
             files = fetchedFiles.css;
         }
@@ -287,9 +295,11 @@ module.exports = {
      * @returns {[String]} The copied files (TODO).
      */
     rewrite_html: async function( options, files = null ){
+        let { flags } = options;
+        let { split, partition } = flags;
 
         if (!files){
-            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "html");
+            let fetchedFiles = await this._fetchFiles(options.dist.fullPathToSource, "html", { split, partition });
             if (!fetchedFiles) return 1;
             files = fetchedFiles.html;
         }
@@ -314,7 +324,7 @@ module.exports = {
         browserSync.init({
             startPath: options.dist.baseurl,
             server: {
-                baseDir: path.join(options.cwd, options.dist.dest)
+                baseDir: Path.join(options.cwd, options.dist.dest)
             },
             port: options.serve.port
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dist",
+  "name": "@cloudcannon/dist",
   "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -4776,11 +4776,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "semver": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
-      "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A=="
     },
     "serve-index": {
       "version": "1.9.1",

--- a/test/cli.js
+++ b/test/cli.js
@@ -62,6 +62,9 @@ describe("setOptions()", function() {
             expect(options.serve.port).to.equal(9898);
             expect(options.dist.dest).to.equal("testdest");
             expect(options.dist.src).to.equal("testsource");
+
+            expect(options.flags.split).to.equal(1);
+            expect(options.flags.partition).to.equal(1);
         })
     })
 })

--- a/test/runner.js
+++ b/test/runner.js
@@ -100,6 +100,64 @@ describe ("_fetchFiles", function() {
         })
     })
 
+    context ("partitions", function() {
+
+        const getPartitionFiles = (partition) => {
+            return Object.keys(partition).reduce((acc, type) => [ ...acc, ...partition[type]], []).sort();
+        };
+
+        before(async function(){
+            this.defaultPartition = await runner._fetchFiles("test/forTesting", "assets");
+            this.partition1 = await runner._fetchFiles("test/forTesting", "assets", { split: 2, partition: 1 });
+            this.partition2 = await runner._fetchFiles("test/forTesting", "assets", { split: 2, partition: 2 });
+        })
+
+        it("prevents invalid `split` or `partition` value", async function () {
+            let partition = await runner._fetchFiles("test/forTesting", "assets", { split: 0, partition: 0 });
+            let files = getPartitionFiles(partition);
+
+            expect(files.length).to.equal(6);
+        });
+
+        it("prevents undefined `split` or `partition` value", async function () {
+            let partition = await runner._fetchFiles("test/forTesting", "assets", { split: undefined, partition: undefined });
+            let files = getPartitionFiles(partition);
+
+            expect(files.length).to.equal(6);
+        });
+
+        it("ensured `partition` is not greater than `split`", async function () {
+            let partition = await runner._fetchFiles("test/forTesting", "assets", { split: 1, partition: 2 });
+            let files = getPartitionFiles(partition);
+
+            expect(files.length).to.equal(6);
+        });
+
+        it("should match default behaviour", async function () {
+            let defaultPartitionFiles = getPartitionFiles(this.defaultPartition);
+            let partition1Files = getPartitionFiles(this.partition1);
+            let partition2Files = getPartitionFiles(this.partition2);
+
+            expect(defaultPartitionFiles).to.eql([...partition1Files, ...partition2Files]);
+        });
+
+        it("should create partitions", async function() {
+            let partition1Files = getPartitionFiles(this.partition1);
+            let partition2Files = getPartitionFiles(this.partition2);
+
+            expect(partition1Files.length).to.equal(3);
+            expect(partition2Files.length).to.equal(3);
+        });
+
+        it("should not have duplicate files", async function() {
+            let partition1Files = getPartitionFiles(this.partition1);
+            let partition2Files = getPartitionFiles(this.partition2);
+            let duplicateFiles = partition1Files.filter(value => partition2Files.includes(value))
+
+            expect(duplicateFiles).to.eql([]);
+        });
+    })
+
     context ("dir doesnt exist", function(){
         it ("should throw an error", async function(){
             let results = await runner._fetchFiles("test/fakeDir");


### PR DESCRIPTION
For large sites it would be nice to divide work up into multiple processes. This adds a `--split=X` and `--partition=X` flag to the `build`, `clone_assets`, `rewrite_css`, and `rewrite_html` commands.

You would use `--split=2` to divide your site files into 2 partitions. Then on a CI, you would have workers processing a partition by adding `--partition=1` or `--partition=2`.

ex:
Worker 1: `--split=2 --partition=1`
Worker 2: `--split=2 --partition=2`
